### PR TITLE
Use the CodeMirror "default" keyMap, instead of "macDefault"

### DIFF
--- a/src/maria/editor.cljs
+++ b/src/maria/editor.cljs
@@ -25,7 +25,7 @@
    :lineNumbers       false
    :lineWrapping      true
    :mode              "clojure"
-   :keyMap            "macDefault"
+   :keyMap            "default"
    :magicBrackets     true
    :magicEdit         true})
 


### PR DESCRIPTION
CodeMirror switches to macDefault automatically when it's on a mac, from the CodeMirror source:

    keyMap["default"] = mac ? keyMap.macDefault : keyMap.pcDefault

Closes #17 