### PR TITLE
Post-ClojureBridge shapes changes

### DIFF
--- a/shapes/src/shapes/core.cljs
+++ b/shapes/src/shapes/core.cljs
@@ -70,6 +70,20 @@
             :stroke "none"
             :fill   "black"}))
 
+(defn ellipse [radius-x radius-y]
+  (assert-number "radius-x must be a number!" radius-x)
+  (assert-number "radius-y must be a number!" radius-y)
+  (->Shape {:is-a   :shape
+            :kind   :ellipse
+            :rx     radius-x
+            :ry     radius-y
+            :cx     radius-x
+            :cy     radius-y
+            :x      (* 1.5 radius-x)
+            :y      (* 1.5 radius-y)
+            :stroke "none"
+            :fill   "black"}))
+
 (defn rectangle
   "Returns a rectangle of `width` and `height`."
   [width height]

--- a/shapes/src/shapes/core.cljs
+++ b/shapes/src/shapes/core.cljs
@@ -85,7 +85,7 @@
             :fill   "black"}))
 
 (defn rectangle
-  "Returns a rectangle of `width` and `height`."
+  "Returns a rectangle of `width` and `height`. See also `square`."
   [width height]
   (assert-number "width must be a number!" width)
   (assert-number "height must be a number!" height)

--- a/shapes/src/shapes/core.cljs
+++ b/shapes/src/shapes/core.cljs
@@ -380,8 +380,8 @@
   "Return `shapes` with their positions adjusted so they're lined up beside one another."
   [& shapes]
   (->> shapes
-       (remove nil?)
        assure-shape-seq
+       (remove nil?)
        reverse
        (reduce (fn [state shape]
                  {:out    (conj (state :out)
@@ -401,8 +401,8 @@
   "Return `shapes` with their positions adjusted so they're stacked above one another."
   [& shapes]
   (->> shapes
-       (remove nil?)
        assure-shape-seq
+       (remove nil?)
        reverse
        (reduce (fn [state shape]
                  {:out     (conj (state :out)

--- a/shapes/src/shapes/core.cljs
+++ b/shapes/src/shapes/core.cljs
@@ -369,17 +369,19 @@
   "Returns a new shape with these `shapes` layered over each other."
   [& shapes]
   (->Shape (assoc (bounds shapes)
-             :is-a :shape
-             :kind :svg
-             :x 0
-             :y 0
-             :children shapes)))
+                  :is-a :shape
+                  :kind :svg
+                  :x 0
+                  :y 0
+                  :children (remove nil? shapes))))
 
 ;; XXX broken for triangles!
 (defn beside
   "Return `shapes` with their positions adjusted so they're lined up beside one another."
   [& shapes]
-  (->> (assure-shape-seq shapes)
+  (->> shapes
+       (remove nil?)
+       assure-shape-seq
        reverse
        (reduce (fn [state shape]
                  {:out    (conj (state :out)
@@ -398,7 +400,9 @@
 (defn above
   "Return `shapes` with their positions adjusted so they're stacked above one another."
   [& shapes]
-  (->> (assure-shape-seq shapes)
+  (->> shapes
+       (remove nil?)
+       assure-shape-seq
        reverse
        (reduce (fn [state shape]
                  {:out     (conj (state :out)


### PR DESCRIPTION
 - adds `ellipse` fn
 - adds reference to `square` in `rectangle`'s docstring
 - removes `nil`s in `beside`, `above`, and `layer`