### PR TITLE
refactor(friendly/messages): override of ana/error-message should be explicit

### DIFF
--- a/editor/src/maria/frames/live_frame.cljs
+++ b/editor/src/maria/frames/live_frame.cljs
@@ -2,6 +2,7 @@
   (:require [maria.pages.live-layout :as repl]
             [maria.eval :as e]
             [maria.friendly.kinds :as kinds]
+            [maria.friendly.messages :as messages]
             [shapes.core :as shapes]
 
             [cells.cell :as cell]
@@ -77,6 +78,8 @@
 (defn init []
 
   @e/compiler-ready
+
+  (messages/override-analyzer-messages!)
 
   (render)
 

--- a/friendly/deps.edn
+++ b/friendly/deps.edn
@@ -1,1 +1,2 @@
-{:paths ["src"]}
+{:deps {org.clojure/clojurescript {:mvn/version "1.10.520"}}
+ :paths ["src"]}


### PR DESCRIPTION
Previously, loading this namespace would have a side-effect of changing analyzer error messages. This PR moves error-message implementations into a map, and adds a new `override-analyzer-messages!` function to install them.

Putting `error-message` implementations in a map makes is easier to see which error messages we haven't yet written a beginner-friendly variant for: see line 161 for a command that can be run at a cljs REPL to see a list of them.

One intent of this PR is to start thinking about how our "friendly" code could be more amenable to community contributions and re-use.