### PR TITLE
Iterate error phrasing

### DIFF
--- a/friendly/src/maria/friendly/messages.cljs
+++ b/friendly/src/maria/friendly/messages.cljs
@@ -56,7 +56,7 @@
       (string/replace "maria.user." "")))
 
 (defn tokenize
-  "Returns lowercase tokens from `s`, limited to the letters [a-z], numbers [0-9], full stop [.], underscore [_], and colon [:]."
+  "Returns lowercase tokens from `s`, limited to the letters [a-z], numbers [0-9], full stop [.], dash [-] (including converted underscore [_]), and colon [:]."
   [s]
   (->> (-> s
            string/lower-case

--- a/friendly/src/maria/friendly/messages.cljs
+++ b/friendly/src/maria/friendly/messages.cljs
@@ -35,10 +35,11 @@
      "shapes.core.circle.call(...).call is not a function"
      "No item 5 in vector of length 0"
      "maria.user.a_fn.call(...).call is not a function"
-     "maria.user.a_b_c_d_fn.call(...).call is not a function"])
+     "maria.user.a_b_c_d_fn.call(...).call is not a function"
+     "(new cljs.core.Keyword(...)).cljs$core$IFn$_invoke$arity$3 is not a function"])
 
-  (tokenize "maria.user.a_fn.call(...).call is not a function")
-
+  (tokenize "(new cljs.core.Keyword(...)).cljs$core$IFn$_invoke$arity$3 is not a function")
+  
   (map (juxt identity tokenize) sample-error-messages)
   
   )
@@ -124,7 +125,10 @@
     ;; don't split on `_`.
     ["% is not a function"
      "The value `%1` isn't a function, but it's being called like one."]
-    
+    ["new keyword % % % % % % % is not a function"
+     (str "A keyword is being called as a function on %7 arguments."
+          "\n\nKeywords can act as functions on a single collection (such as a map or set), but keywords-as-functions can't take %7 arguments.")]
+
     ["Could not compile"
      (str "Compile error."
           "\n\nWe were unable to turn this expression into JavaScript. 😰")]    

--- a/friendly/src/maria/friendly/messages.cljs
+++ b/friendly/src/maria/friendly/messages.cljs
@@ -78,8 +78,15 @@
   "A search trie for matching error messages to templates."
   (build-error-message-trie
    [["f is null"
-     (str "`nil` is not a valid function."
-          "\n\nAt some point I expected a function but found `nil` instead.")]
+     (str "Expected a function but found `nil`."
+          "\n\nAt some point I found `nil` where a function should be, such as in a higher-order function like `map` or `keep`. `nil` is not a valid function.")]
+    ["pred is null"
+     (str "Expected a predicate function but found `nil`."
+          "\n\nAt some point I found `nil` where a predicate function should be, like in a `filter` or `some`. Predicate functions cannot be `nil`.")]
+    ["% is null"
+     (str "Expected a composable function but found `nil`."
+          "\n\nAt some point I found `nil` where a function should be passed to a higher-order composition function, like a `comp` or `juxt`. It was found at position `%1`. `nil` is not a valid part of function composition.")]
+
     ["cannot read property call of %" ;; FIXME can't replicate -- appears to come from JS-land?
      "It looks like you're trying to call a function that has not been defined yet. 🙀"]
     ["invalid arity: %" ;; NB: a similar situation is handled by `:fn-arity` analyzer message case

--- a/friendly/src/maria/friendly/messages.cljs
+++ b/friendly/src/maria/friendly/messages.cljs
@@ -75,7 +75,6 @@
           templates))
 
 (def error-message-trie
-  ;; TODO verify these are working. On spot-check several are broken.
   "A search trie for matching error messages to templates."
   (build-error-message-trie
    [["f is null"


### PR DESCRIPTION
This PR makes a small change to tokenization of error messages, but mostly updates the phrasing of several errors. I also rearranged the error trie to group like with like.

It would be nice if someone did a test drive through the demo doc ([production](https://www.maria.cloud/gist/fb460019eccd9b49ff5fb3465eea08b7?eval=true) and [localhost](https://localhost:8702/gist/fb460019eccd9b49ff5fb3465eea08b7)) with these changes, to double-check as well as to provide feedback. There's a lot of room for improvement on these error messages and I hope to spend some more time on it this week.