### PR TITLE
London ClojureBridge curriculum link

### DIFF
--- a/editor/src/maria/curriculum.cljs
+++ b/editor/src/maria/curriculum.cljs
@@ -13,6 +13,7 @@
    ["data-flow" "Data Flow" (repo-path "curriculum/Data Flow.cljs")]
    ["shannons-entropy" "Shannon's Entropy" (repo-path "curriculum/Shannon's Entropy.cljs")]
    ["cb-intro" "Learn Clojure with Shapes (ClojureBridge)" (repo-path "curriculum/Learn Clojure with Shapes (ClojureBridge).cljs")]
+   ["cb-london" "London ClojureBridge" (js/encodeURIComponent "https://gist.githubusercontent.com/londonclojurians/9afbc2adf3638f1bcf6a6c08b6f33226/raw/c6f7f957d2bf293185b1dc6fc532d282f411e886/clojurebridge-shapes.cljs")]
    ["cb-coaches" "ClojureBridge Coaches' Copy" (repo-path "curriculum/ClojureBridge Coaches' Copy.cljs")]])
 
 (def owner {:username  "curriculum"

--- a/editor/src/maria/pages/live_layout.cljs
+++ b/editor/src/maria/pages/live_layout.cljs
@@ -39,8 +39,8 @@
      "Your journey begins here: "
      [:a.br2.bg-white.shadow-4.pa3.ml3.sans-serif.black.no-underline.f5.b.pointer.hover-underline.hover-shadow-5 {:href "/intro"} "Learn Clojure with Shapes"]
      [:.flex-auto]]
-
-    [:.tc.i.f3.mv3 "More reading:"]
+    
+    [:.tc.i.f3.mv3 "Further reading:"]
 
     [:ul.f-body.tl.lh-copy
      [:li "The " [:a {:href "/quickstart"} "Editor Quickstart"] ", if you're already familiar with Clojure."]
@@ -48,8 +48,12 @@
      [:li "Understand the " [:a {:target "_blank"
                                  :href   "https://github.com/mhuebert/maria/wiki/Curriculum"} "Pedagogy"] " behind Maria's curriculum."]
      [:li "Discover the " [:a {:target "_blank"
-                               :href   "https://github.com/mhuebert/maria/wiki/Background-reading"} "Sources of Inspiration"] " for the project."]]]
-   ])
+                               :href   "https://github.com/mhuebert/maria/wiki/Background-reading"} "Sources of Inspiration"] " for the project."]]
+    
+    [:.tc.i.f3.mv3 "Events:"]
+
+    [:ul.f-body.tl.lh-copy
+     [:li "Feb 2020, London ClojureBridge: " [:a {:href "/cb-london"} "start here"] "."]]]])
 
 (v/defn sidebar
   [{:keys [visible? id]}]


### PR DESCRIPTION
Modifies landing page to include "Events" section. Adds London ClojureBridge to `/cb-london`.