### PR TITLE
fix missing hyphen from error messages

### DIFF
--- a/friendly/src/maria/friendly/messages.cljs
+++ b/friendly/src/maria/friendly/messages.cljs
@@ -61,7 +61,7 @@
   (->> (-> s
            string/lower-case
            sanitize-js-error
-           (string/split #"[^a-z%0-9%\.%:%_]"))
+           (string/split #"[^a-z%0-9%\.%:%_%-]"))
        (map #(string/replace % "_" "-")) ;; this must happen in post-processing so we don't split on underscores-turned-to-dashes
        (remove empty?)
        (into [])))


### PR DESCRIPTION
PR to resolve missing hyphen bug reported here: https://github.com/mhuebert/maria/issues/275

As per this screenshot, this two character edit seems to fix the bug. Are there any tests I can run to confirm that there are no regressions?

![Screenshot from 2023-09-02 18-11-40](https://github.com/mhuebert/maria/assets/6962664/a1a060b1-7a8f-48c0-8be7-dc89970d7a5f)
